### PR TITLE
Fix kmagent Not Picking docker-col-config.yaml in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,4 @@ COPY ./configs/agent-config.yaml /var/kloudmate/agent-config.yaml
 COPY ./configs/host-col-config.yaml /var/kloudmate/host-col-config.yaml
 COPY ./configs/docker-col-config.yaml /var/kloudmate/docker-col-config.yaml
 
-CMD ["./kmagent install"]
-CMD ["./kmagent -mode=docker start"]
+CMD ["./kmagent", "-mode=docker", "start"]

--- a/cmd/kmagent/kmagent.go
+++ b/cmd/kmagent/kmagent.go
@@ -41,7 +41,7 @@ func main() {
 		Flags:    prg.CliArgs(),
 		Commands: prg.CliCommands(s),
 	}
-	prg.InitCollector(app)
+	// prg.InitCollector(app)
 	// prg.ApplyAgentConfig(cli.NewContext(app, nil, nil))
 
 	// show help when no command specified

--- a/internal/agent/background_service.go
+++ b/internal/agent/background_service.go
@@ -40,12 +40,6 @@ type agentYaml struct {
 func NewKmAgentService() (s *KmAgentService, err error) {
 	svc := &KmAgentService{}
 
-	if _, err := os.Stat("/.dockerenv"); err == nil {
-		svc.Mode = containerMode
-	} else {
-		svc.Mode = hostMode
-	}
-
 	// Token:     "",
 	svc.AgentCfg = agentYaml{}
 	svc.Exit = make(chan struct{})
@@ -86,14 +80,14 @@ func NewKmAgentService() (s *KmAgentService, err error) {
 	return s, nil
 }
 
-func (r *KmAgentService) InitCollector(app *cli.App) (err error) {
-	r.ApplyAgentConfig(cli.NewContext(app, nil, nil))
-	r.Collector, err = collector.NewKmCollector(r.Configs)
-	if err != nil {
-		return err
-	}
-	return nil
-}
+// func (r *KmAgentService) InitCollector(app *cli.App) (err error) {
+// 	r.ApplyAgentConfig(cli.NewContext(app, nil, nil))
+// 	r.Collector, err = collector.NewKmCollector(r.Configs)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	return nil
+// }
 
 func (svc *KmAgentService) asyncWork() {
 	if err := svc.Collector.Run(context.Background()); err != nil {
@@ -170,6 +164,7 @@ func (svc *KmAgentService) ApplyAgentConfig(c *cli.Context) {
 	svc.Configs.ConfigProviderSettings.ResolverSettings.DefaultScheme = "yaml"
 
 	if svc.Mode == containerMode {
+		svc.Svclogger.Infof("This is the path of Docker config file: %s", DOCKER_CONFIG_FILE_URI)
 		svc.Configs.ConfigProviderSettings.ResolverSettings.URIs =
 			[]string{
 				"file:" + DOCKER_CONFIG_FILE_URI,
@@ -178,6 +173,7 @@ func (svc *KmAgentService) ApplyAgentConfig(c *cli.Context) {
 				endpointUri,
 			}
 	} else {
+		svc.Svclogger.Infof("This is the path of Host config file: %s", HOST_CONFIG_FILE_URI)
 		svc.Configs.ConfigProviderSettings.ResolverSettings.URIs =
 			[]string{
 				"file:" + HOST_CONFIG_FILE_URI,

--- a/internal/agent/background_service.go
+++ b/internal/agent/background_service.go
@@ -39,7 +39,13 @@ type agentYaml struct {
 // Constructor for the KmAgentService with default configurations
 func NewKmAgentService() (s *KmAgentService, err error) {
 	svc := &KmAgentService{}
-	svc.Mode = hostMode
+
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		svc.Mode = containerMode
+	} else {
+		svc.Mode = hostMode
+	}
+
 	// Token:     "",
 	svc.AgentCfg = agentYaml{}
 	svc.Exit = make(chan struct{})
@@ -124,7 +130,9 @@ func (svc *KmAgentService) ApplyAgentConfig(c *cli.Context) {
 	}
 
 	// if empty and not set on env then use the key from the agent configuration
-	if svc.AgentCfg.Key == "" {
+	if key, exists := os.LookupEnv("KM_API_KEY"); exists {
+		svc.AgentCfg.Key = key
+	} else {
 		svc.AgentCfg.Key = agentParsedData.Key
 	}
 

--- a/internal/agent/background_service.go
+++ b/internal/agent/background_service.go
@@ -8,7 +8,6 @@ import (
 
 	bgsvc "github.com/kardianos/service"
 	"github.com/kloudmate/km-agent/internal/collector"
-	cli "github.com/urfave/cli/v2"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/provider/envprovider"
@@ -80,14 +79,14 @@ func NewKmAgentService() (s *KmAgentService, err error) {
 	return s, nil
 }
 
-// func (r *KmAgentService) InitCollector(app *cli.App) (err error) {
-// 	r.ApplyAgentConfig(cli.NewContext(app, nil, nil))
-// 	r.Collector, err = collector.NewKmCollector(r.Configs)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	return nil
-// }
+func (r *KmAgentService) InitCollector() (err error) {
+	r.ApplyAgentConfig()
+	r.Collector, err = collector.NewKmCollector(r.Configs)
+	if err != nil {
+		return err
+	}
+	return nil
+}
 
 func (svc *KmAgentService) asyncWork() {
 	if err := svc.Collector.Run(context.Background()); err != nil {
@@ -97,6 +96,7 @@ func (svc *KmAgentService) asyncWork() {
 
 func (svc *KmAgentService) Start(s bgsvc.Service) error {
 	svc.Svclogger.Infof("Running agent on %s mode \n", svc.Mode)
+	svc.InitCollector()
 	go svc.asyncWork()
 	return nil
 }
@@ -109,7 +109,7 @@ func (svc *KmAgentService) Stop(s bgsvc.Service) error {
 }
 
 // ApplyAgentConfig is used to apply KM paramaters on the collector configuration.
-func (svc *KmAgentService) ApplyAgentConfig(c *cli.Context) {
+func (svc *KmAgentService) ApplyAgentConfig() {
 	svc.AgentCfg.debugLevel = "normal"
 	svc.AgentCfg.Interval = "10s"
 

--- a/internal/agent/cli_args.go
+++ b/internal/agent/cli_args.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"github.com/kloudmate/km-agent/internal/collector"
 	cli "github.com/urfave/cli/v2"
 
 	bgsvc "github.com/kardianos/service"
@@ -98,7 +99,8 @@ func (p *KmAgentService) CliCommands(s bgsvc.Service) []*cli.Command {
 			Name:  startCommand,
 			Usage: "Start the service",
 			Action: func(c *cli.Context) error {
-				// p.ApplyAgentConfig(c)
+				p.ApplyAgentConfig(c)
+				p.Collector, _ = collector.NewKmCollector(p.Configs)
 				err := s.Run()
 				if err != nil {
 					logger.Error(err)

--- a/internal/agent/cli_args.go
+++ b/internal/agent/cli_args.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"github.com/kloudmate/km-agent/internal/collector"
 	cli "github.com/urfave/cli/v2"
 
 	bgsvc "github.com/kardianos/service"
@@ -99,8 +98,6 @@ func (p *KmAgentService) CliCommands(s bgsvc.Service) []*cli.Command {
 			Name:  startCommand,
 			Usage: "Start the service",
 			Action: func(c *cli.Context) error {
-				p.ApplyAgentConfig(c)
-				p.Collector, _ = collector.NewKmCollector(p.Configs)
 				err := s.Run()
 				if err != nil {
 					logger.Error(err)


### PR DESCRIPTION
## Description:
This PR fixes the issue #12  where kmagent incorrectly picks host-col-config.yaml instead of docker-col-config.yaml when running inside a Docker container. The application now correctly detects the environment and loads the appropriate configuration file.