### PR TITLE
WIP : Workflow for the binaries to rollout on releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,7 @@ on:
 
 permissions:
   contents: write
-  # will be required in future if we need to push image to docker.
-  # packages: write
+  packages: write
   # issues: write
 
 jobs:
@@ -35,4 +34,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          # GORELEASER_KEY: ${{secrets.GORELEASER_KEY}} applicable only and only if `goreleaser-pro` is used.

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ go.work.sum
 
 # env file
 .env
+# Added by goreleaser init:
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,46 @@
+version: 2
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+
+builds:
+  - main: ./cmd/kmagent
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      # - darwin
+
+archives:
+  - formats: [tar.gz]
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  footer: >-
+
+    ---
+
+    [Kloudmate](https://kloudmate.com)


### PR DESCRIPTION
Implementation includes automated GitHub Actions workflow that builds binaries whenever a new release is created.

## Changes

- Added a new GitHub Action workflow file that triggers on release events
- Configured the workflow to build ClickHouse binaries for supported platforms
- Set up artifact storage for the built binaries
- Added appropriate release tagging in the workflow

## Checklist

- [x] create releases with versioning i.e - (`MAJOR.MINOR.PATCH`)
- [ ] Semantic version checking for PR to follow a symmetric standard
- [ ] Binary builds on releases