### PR TITLE
updated configmap for daemonset and deployment 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+reviewers:
+  - "amitava82"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-reviewers:
-  - "amitava82"
+* @amitava82

--- a/cmd/configupdater/main.go
+++ b/cmd/configupdater/main.go
@@ -66,14 +66,24 @@ func updaterFlags(cfg *config.K8sAgentConfig) []cli.Flag {
 			Destination: &cfg.KubeNamespace,
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
-			Name:        "configmap-name",
-			EnvVars:     []string{"KM_CONFIGMAP_NAME"},
-			Destination: &cfg.ConfigmapName,
+			Name:        "configmap-daemonset-name",
+			EnvVars:     []string{"CONFIGMAP_DAEMONSET_NAME"},
+			Destination: &cfg.ConfigmapDaemonsetName,
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:        "configmap-deployment-name",
+			EnvVars:     []string{"CONFIGMAP_DEPLOYMENT_NAME"},
+			Destination: &cfg.ConfigmapDeploymentName,
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:        "daemonset-name",
 			EnvVars:     []string{"KM_DAEMONSET_NAME"},
 			Destination: &cfg.DaemonSetName,
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:        "deployment-name",
+			EnvVars:     []string{"KM_DEPLOYMENT_NAME"},
+			Destination: &cfg.DeploymentName,
 		}),
 	}
 }
@@ -117,6 +127,7 @@ func main() {
 						return err
 					}
 					kubeUpdater := updater.NewKubeConfigUpdaterClient(kubeAgentConfig, logger.Sugar())
+					kubeUpdater.SetConfigPath()
 
 					var wg sync.WaitGroup
 					errCh := make(chan error)

--- a/deployment/helm/km-kube-agent/Chart.yaml
+++ b/deployment/helm/km-kube-agent/Chart.yaml
@@ -15,6 +15,7 @@ keywords:
   - tracing
   - logs
   - metrics
+  - apm
 sources:
   - https://github.com/kloudmate/km-agent
 maintainers:

--- a/deployment/helm/km-kube-agent/templates/_helpers.tpl
+++ b/deployment/helm/km-kube-agent/templates/_helpers.tpl
@@ -1,14 +1,33 @@
-{{/*
-Expand the name of the chart.
+{{- /*
+Common labels for all resources.
+This is a good practice to ensure consistency across the entire chart.
 */}}
-{{- define "km-kube-agent.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- define "km-kube-agent.labels" -}}
+helm.sh/chart: {{ include "km-kube-agent.chart" . }}
+{{- with .Values.podLabels }}
+{{- toYaml . }}
+{{- end }}
 {{- end }}
 
-{{/*
+{{- /*
+Selector labels for the various workloads.
+These labels are used in Deployment and DaemonSet selectors.
+*/}}
+{{- define "km-kube-agent.daemonset.selectorLabels" -}}
+{{- toYaml .Values.daemonsetLabels }}
+{{- end }}
+
+{{- define "km-kube-agent.deployment.selectorLabels" -}}
+{{- toYaml .Values.deploymentLabels }}
+{{- end }}
+
+{{- define "km-kube-agent.configUpdater.selectorLabels" -}}
+{{- toYaml .Values.configUpdaterLabels }}
+{{- end }}
+
+{{- /*
 Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
+We truncate it at 63 chars because of K8s name restrictions.
 */}}
 {{- define "km-kube-agent.fullname" -}}
 {{- if .Values.fullnameOverride }}
@@ -23,46 +42,9 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
-{{/*
-Create chart name and version as used by the chart label.
+{{- /*
+Create the name of the chart.
 */}}
 {{- define "km-kube-agent.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Common labels
-*/}}
-{{- define "km-kube-agent.labels" -}}
-helm.sh/chart: {{ include "km-kube-agent.chart" . }}
-{{ include "km-kube-agent.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- with .Values.extraLabels }}
-{{ toYaml . }}
-{{- end }}     
-{{- end }}
-
-{{/*
-Selector labels
-*/}}
-{{- define "km-kube-agent.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "km-kube-agent.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- with .Values.selectorLabels }}
-{{ toYaml . }}
-{{- end }}
-{{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "km-kube-agent.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "km-kube-agent.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
 {{- end }}

--- a/deployment/helm/km-kube-agent/templates/agent-configmap-daemonset.yaml
+++ b/deployment/helm/km-kube-agent/templates/agent-configmap-daemonset.yaml
@@ -1,8 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.configMapDaemonset.name }}
+  name: {{ .Values.configMapDaemonsetName }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- toYaml .Values.configMapDaemonsetLabels | nindent 4 }}
 data:
   # The key here will become the filename inside the mountPath.
   # We name it exactly "agent.config.yaml" so it appears as such.

--- a/deployment/helm/km-kube-agent/templates/agent-configmap-daemonset.yaml
+++ b/deployment/helm/km-kube-agent/templates/agent-configmap-daemonset.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.configMap.name }}
+  name: {{ .Values.configMapDaemonset.name }}
   namespace: {{ .Release.Namespace }}
 data:
   # The key here will become the filename inside the mountPath.

--- a/deployment/helm/km-kube-agent/templates/agent-configmap-deployment.yaml
+++ b/deployment/helm/km-kube-agent/templates/agent-configmap-deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.configMapDeployment.name }}
+  namespace: {{ .Release.Namespace }}
+data:
+  # The key here will become the filename inside the mountPath.
+  # We name it exactly "agent.config.yaml" so it appears as such.
+  agent.yaml: |
+
+    receivers:
+      otlp:
+        protocols:
+          grpc: 
+            endpoint: '0.0.0.0:4317'
+          http:
+            endpoint: '0.0.0.0:4318'
+      k8s_cluster:
+        auth_type: serviceAccount
+        node_conditions_to_report:
+          - Ready
+          - MemoryPressure
+        allocatable_types_to_report:
+          - cpu
+          - memory
+        metrics:
+          k8s.container.cpu_limit:
+            enabled: true
+        resource_attributes:
+          container.id:
+            enabled: true
+    processors:
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+    exporters:
+      debug:
+        verbosity: detailed
+      otlphttp:
+        endpoint: {{ .Values.COLLECTOR_ENDPOINT | default "https://otel.kloudmate.com:4318" }}
+        headers:
+          Authorization: {{ .Values.API_KEY }}
+    service:
+      pipelines:
+        traces:
+          receivers:
+            - otlp
+          processors:
+            - batch
+          exporters:
+            - debug
+            - otlphttp
+        metrics:
+          receivers:
+            - otlp
+            - k8s_cluster
+          processors:
+            - batch
+          exporters:
+            - debug
+            - otlphttp
+        logs:
+          receivers:
+            - otlp
+          processors:
+            - batch
+          exporters:
+            - debug
+            - otlphttp

--- a/deployment/helm/km-kube-agent/templates/agent-configmap-deployment.yaml
+++ b/deployment/helm/km-kube-agent/templates/agent-configmap-deployment.yaml
@@ -1,8 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.configMapDeployment.name }}
+  name: {{ .Values.configMapDeploymentName }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- toYaml .Values.configMapDeploymentLabels | nindent 4 }}
 data:
   # The key here will become the filename inside the mountPath.
   # We name it exactly "agent.config.yaml" so it appears as such.

--- a/deployment/helm/km-kube-agent/templates/agent-daemonset.yaml
+++ b/deployment/helm/km-kube-agent/templates/agent-daemonset.yaml
@@ -4,27 +4,23 @@ metadata:
   name: {{ .Values.daemonsetName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "km-kube-agent.labels" . | nindent 4 }}
+    {{- toYaml .Values.daemonsetLabels | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ .Values.daemonsetName }}
-      {{- include "km-kube-agent.selectorLabels" . | nindent 6 }}
+      mapped-with: {{ .Values.daemonsetName }}
+      {{- toYaml .Values.daemonsetLabels | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ .Values.daemonsetName }}
-        {{- include "km-kube-agent.selectorLabels" . | nindent 8 }}
+        mapped-with: {{ .Values.daemonsetName }}
+        {{- toYaml .Values.daemonsetLabels | nindent 8 }}
     spec:
-      serviceAccountName: {{ .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
       containers:
         - name: kloudmate-km-kube-agent
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.args }}
-          args:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           env:
             - name: KM_API_KEY
               value: {{ .Values.API_KEY }}

--- a/deployment/helm/km-kube-agent/templates/agent-daemonset.yaml
+++ b/deployment/helm/km-kube-agent/templates/agent-daemonset.yaml
@@ -28,8 +28,10 @@ spec:
               value: {{ .Values.COLLECTOR_ENDPOINT | default "https://otel.kloudmate.com:4318" }}
             - name: KM_CONFIG_CHECK_INTERVAL
               value: {{ .Values.KM_CONFIG_CHECK_INTERVAL | default "30s" }}
+            - name: DEPLOYMENT_MODE
+              value: DAEMONSET
               ## for daemonset
-            - name: CONFIGMAP_DAEMONSET_NAME
+            - name: CONFIGMAP_NAME
               value: {{ .Values.configMapDaemonsetName }}
             - name: POD_NAMESPACE
               valueFrom:
@@ -47,7 +49,7 @@ spec:
             - name: agent-config-volume-daemonset
               mountPath: "/etc/kmagent/agent-daemonset.yaml"
               readOnly: true
-              subPath: "agent.yaml"
+              subPath: "agent-daemonset.yaml"
             - name: varlog
               mountPath: /var/log
               readOnly: true

--- a/deployment/helm/km-kube-agent/templates/agent-daemonset.yaml
+++ b/deployment/helm/km-kube-agent/templates/agent-daemonset.yaml
@@ -30,7 +30,7 @@ spec:
               value: {{ .Values.KM_CONFIG_CHECK_INTERVAL | default "30s" }}
               ## for daemonset
             - name: CONFIGMAP_DAEMONSET_NAME
-              value: {{ .Values.configMapDaemonset.name }}
+              value: {{ .Values.configMapDaemonsetName }}
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -58,7 +58,7 @@ spec:
         - name: agent-config-volume-daemonset
           configMap:
             ## for daemonset
-            name: {{ .Values.configMapDaemonset.name }}
+            name: {{ .Values.configMapDaemonsetName }}
         - name: varlog
           hostPath:
             path: /var/log

--- a/deployment/helm/km-kube-agent/templates/agent-deployment.yaml
+++ b/deployment/helm/km-kube-agent/templates/agent-deployment.yaml
@@ -36,8 +36,10 @@ spec:
               value: {{ .Values.COLLECTOR_ENDPOINT | default "https://otel.kloudmate.com:4318" }}
             - name: KM_CONFIG_CHECK_INTERVAL
               value: {{ .Values.KM_CONFIG_CHECK_INTERVAL | default "30s" }}
+            - name: DEPLOYMENT_MODE
+              value: DEPLOYMENT
               ## for deployment
-            - name: CONFIGMAP_DEPLOYMENT_NAME
+            - name: CONFIGMAP_NAME
               value: {{ .Values.configMapDeploymentName }}
             - name: POD_NAMESPACE
               valueFrom:
@@ -56,7 +58,7 @@ spec:
             - name: agent-config-volume-deployment
               mountPath: "/etc/kmagent/agent-deployment.yaml"
               readOnly: true
-              subPath: "agent.yaml"
+              subPath: "agent-deployment.yaml"
       volumes:
         - name: agent-config-volume-deployment
           configMap:

--- a/deployment/helm/km-kube-agent/templates/agent-deployment.yaml
+++ b/deployment/helm/km-kube-agent/templates/agent-deployment.yaml
@@ -38,7 +38,7 @@ spec:
               value: {{ .Values.KM_CONFIG_CHECK_INTERVAL | default "30s" }}
               ## for deployment
             - name: CONFIGMAP_DEPLOYMENT_NAME
-              value: {{ .Values.configMapDeployment.name }}
+              value: {{ .Values.configMapDeploymentName }}
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -61,4 +61,4 @@ spec:
         - name: agent-config-volume-deployment
           configMap:
             ## for deployment
-            name: {{ .Values.configMapDeployment.name }}
+            name: {{ .Values.configMapDeploymentName }}

--- a/deployment/helm/km-kube-agent/templates/agent-deployment.yaml
+++ b/deployment/helm/km-kube-agent/templates/agent-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ .Values.deploymentName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "km-kube-agent.labels" . | nindent 4 }}
+    {{- toYaml .Values.configMapDeploymentLabels | nindent 4 }}
 spec:
   # 'replicas' is a key field for a Deployment. We set it to 1 to ensure
   # a single, non-redundant instance is running. This is crucial for
@@ -17,22 +17,18 @@ spec:
   selector:
     matchLabels:
       app: {{ .Values.deploymentName }}
-      {{- include "km-kube-agent.selectorLabels" . | nindent 6 }}
+      {{- toYaml .Values.configMapDeploymentLabels | nindent 6 }}
   template:
     metadata:
       labels:
         app: {{ .Values.deploymentName }}
-        {{- include "km-kube-agent.selectorLabels" . | nindent 8 }}
+        {{- toYaml .Values.configMapDeploymentLabels | nindent 8 }}
     spec:
-      serviceAccountName: {{ .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
       containers:
         - name: kloudmate-km-kube-agent-cluster
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.args }}
-          args:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           env:
             - name: KM_API_KEY
               value: {{ .Values.API_KEY }}
@@ -40,8 +36,9 @@ spec:
               value: {{ .Values.COLLECTOR_ENDPOINT | default "https://otel.kloudmate.com:4318" }}
             - name: KM_CONFIG_CHECK_INTERVAL
               value: {{ .Values.KM_CONFIG_CHECK_INTERVAL | default "30s" }}
-            - name: CONFIGMAP_NAME
-              value: {{ .Values.configMap.name }}
+              ## for deployment
+            - name: CONFIGMAP_DEPLOYMENT_NAME
+              value: {{ .Values.configMapDeployment.name }}
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -56,8 +53,8 @@ spec:
               containerPort: 4318
               protocol: TCP
           volumeMounts:
-            - name: agent-config-volume
-              mountPath: "/etc/kmagent/agent.yaml"
+            - name: agent-config-volume-deployment
+              mountPath: "/etc/kmagent/agent-deployment.yaml"
               readOnly: true
               subPath: "agent.yaml"
       volumes:

--- a/deployment/helm/km-kube-agent/templates/agent-deployment.yaml
+++ b/deployment/helm/km-kube-agent/templates/agent-deployment.yaml
@@ -1,24 +1,32 @@
+# Deployment manifest for a cluster-level agent.
+# It is based on the provided DaemonSet configuration but has been
+# adapted to run as a single, highly available pod to collect cluster-wide data.
+
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
-  name: {{ .Values.daemonsetName }}
+  name: {{ .Values.deploymentName }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "km-kube-agent.labels" . | nindent 4 }}
 spec:
+  # 'replicas' is a key field for a Deployment. We set it to 1 to ensure
+  # a single, non-redundant instance is running. This is crucial for
+  # collecting cluster-wide data without duplication.
+  replicas: 1
   selector:
     matchLabels:
-      app: {{ .Values.daemonsetName }}
+      app: {{ .Values.deploymentName }}
       {{- include "km-kube-agent.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ .Values.daemonsetName }}
+        app: {{ .Values.deploymentName }}
         {{- include "km-kube-agent.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:
-        - name: kloudmate-km-kube-agent
+        - name: kloudmate-km-kube-agent-cluster
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.args }}
@@ -32,14 +40,15 @@ spec:
               value: {{ .Values.COLLECTOR_ENDPOINT | default "https://otel.kloudmate.com:4318" }}
             - name: KM_CONFIG_CHECK_INTERVAL
               value: {{ .Values.KM_CONFIG_CHECK_INTERVAL | default "30s" }}
-              ## for daemonset
-            - name: CONFIGMAP_DAEMONSET_NAME
-              value: {{ .Values.configMapDaemonset.name }}
+            - name: CONFIGMAP_NAME
+              value: {{ .Values.configMap.name }}
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
           ports:
+            # We keep the OTLP ports to allow other components (like the
+            # DaemonSet agents) to send data to this cluster agent.
             - name: otlp-grpc
               containerPort: 4317
               protocol: TCP
@@ -47,25 +56,12 @@ spec:
               containerPort: 4318
               protocol: TCP
           volumeMounts:
-              ## for daemonset 
-            - name: agent-config-volume-daemonset
-              mountPath: "/etc/kmagent/agent-daemonset.yaml"
+            - name: agent-config-volume
+              mountPath: "/etc/kmagent/agent.yaml"
               readOnly: true
               subPath: "agent.yaml"
-            - name: varlog
-              mountPath: /var/log
-              readOnly: true
-            - name: rootfs
-              mountPath: /host
-              readOnly: true
       volumes:
-        - name: agent-config-volume-daemonset
+        - name: agent-config-volume-deployment
           configMap:
-            ## for daemonset
-            name: {{ .Values.configMapDaemonset.name }}
-        - name: varlog
-          hostPath:
-            path: /var/log
-        - name: rootfs
-          hostPath:
-            path: /
+            ## for deployment
+            name: {{ .Values.configMapDeployment.name }}

--- a/deployment/helm/km-kube-agent/templates/agent-svc.yaml
+++ b/deployment/helm/km-kube-agent/templates/agent-svc.yaml
@@ -3,9 +3,11 @@ kind: Service
 metadata:
   name: {{ .Values.agentServiceName }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- toYaml .Values.serviceLabels | nindent 4 }}
 spec:
   selector:
-    app: {{ .Values.daemonsetName }}
+    mapped-with: {{ .Values.daemonsetName }}
   ports:
     - name: otlp-grpc-service
       protocol: TCP
@@ -16,3 +18,4 @@ spec:
       port: 4318
       targetPort: otlp-http
   type: ClusterIP
+  internalTrafficPolicy: Local

--- a/deployment/helm/km-kube-agent/templates/cluster-role-binding.yaml
+++ b/deployment/helm/km-kube-agent/templates/cluster-role-binding.yaml
@@ -1,20 +1,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  # The name is generated using the helper template for consistency.
-  name: {{ .Values.rbac.ClusterRoleBindingName }}
-  namespace: {{ .Values.rbac.ClusterRoleBindingNamespace }}
-
+  name: {{ .Values.clusterRoleBindingName }}
+  namespace: {{ .Values.clusterRoleBindingNamespace }}
   labels:
-    {{- include "km-kube-agent.labels" . | nindent 4 }}
+    {{- toYaml .Values.clusterRoleBindingLabels | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  # The name of the ClusterRole is configurable via values.yaml.
-  name: {{ .Values.rbac.clusterRoleName }}
+  name: {{ .Values.clusterRoleName }}
 subjects:
 - kind: ServiceAccount
-  # The ServiceAccount name is taken from values.yaml for consistency.
-  name: {{ .Values.serviceAccount.name }}
-  # The namespace is the one where the chart is being released.
+  name: {{ .Values.serviceAccountName }}
   namespace: {{ .Release.Namespace }}

--- a/deployment/helm/km-kube-agent/templates/cluster-role.yaml
+++ b/deployment/helm/km-kube-agent/templates/cluster-role.yaml
@@ -1,11 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.rbac.clusterRoleName }}
-  namespace: {{ .Values.rbac.clusterRoleNamespace }}
-
+  name: {{ .Values.clusterRoleName }}
+  namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "km-kube-agent.labels" . | nindent 4 }}
+    {{- toYaml .Values.clusterRoleLabels | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["nodes", "pods", "services", "endpoints", "namespaces", "configmaps", "secrets", "events", "persistentvolumes", "replicationcontrollers", "resourcequotas"]

--- a/deployment/helm/km-kube-agent/templates/config-updater-deployment.yaml
+++ b/deployment/helm/km-kube-agent/templates/config-updater-deployment.yaml
@@ -1,28 +1,26 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kloudmate-config-updater
+  name: {{ .Values.configUpdaterName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: kloudmate-config-updater
+    {{- toYaml .Values.configUpdaterLabels | nindent 4 }}
 spec:
   # replica is 1 to ensure a single instance is running
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: kloudmate-config-updater
+      {{- toYaml .Values.configUpdaterLabels | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: kloudmate-config-updater
+        {{- toYaml .Values.configUpdaterLabels | nindent 8 }}
     spec:
-      serviceAccountName: {{ .Values.serviceAccount.name }}
-
+      serviceAccountName: {{ .Values.serviceAccountName }}
       containers:
         - name: config-updater
           image: "{{ .Values.configUpdater.image.repository }}:{{ .Values.configUpdater.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.configUpdater.image.pullPolicy }}
-
           env:
             - name: KM_API_KEY
               value: {{ .Values.API_KEY }}
@@ -48,7 +46,6 @@ spec:
               value: {{ .Values.daemonsetName }}
             - name: KM_DEPLOYMENT_NAME
               value: {{ .Values.deploymentName }}
-
           volumeMounts:
               ## for daemonset 
             - name: agent-config-volume-daemonset
@@ -60,7 +57,6 @@ spec:
               mountPath: "/etc/kmagent/agent-deployment.yaml"
               readOnly: true
               subPath: "agent.yaml"
-
           resources:
             requests:
               cpu: "100m"

--- a/deployment/helm/km-kube-agent/templates/config-updater-deployment.yaml
+++ b/deployment/helm/km-kube-agent/templates/config-updater-deployment.yaml
@@ -32,10 +32,10 @@ spec:
               value: {{ .Values.KM_UPDATE_ENDPOINT | default "https://api.kloudmate.com/agents/config-check" }}
               ## for daemonset
             - name: CONFIGMAP_DAEMONSET_NAME
-              value: {{ .Values.configMapDaemonset.name }}
+              value: {{ .Values.configMapDaemonsetName }}
               ## for deployment
             - name: CONFIGMAP_DEPLOYMENT_NAME
-              value: {{ .Values.configMapDeployment.name }}
+              value: {{ .Values.configMapDeploymentName }}
             - name: KM_CLUSTER_NAME
               value: {{ .Values.clusterName }}
             - name: KM_NAMESPACE
@@ -69,8 +69,8 @@ spec:
         - name: agent-config-volume-daemonset
           configMap:
             ## for daemonset
-            name: {{ .Values.configMapDaemonset.name }}
+            name: {{ .Values.configMapDaemonsetName }}
         - name: agent-config-volume-deployment
           configMap:
             ## for deployment
-            name: {{ .Values.configMapDeployment.name }}
+            name: {{ .Values.configMapDeploymentName }}

--- a/deployment/helm/km-kube-agent/templates/config-updater-deployment.yaml
+++ b/deployment/helm/km-kube-agent/templates/config-updater-deployment.yaml
@@ -1,5 +1,3 @@
-# filename: updater-deployment.yaml
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,8 +32,12 @@ spec:
               value: {{ .Values.KM_CONFIG_CHECK_INTERVAL | default "30s" }}
             - name: KM_UPDATE_ENDPOINT
               value: {{ .Values.KM_UPDATE_ENDPOINT | default "https://api.kloudmate.com/agents/config-check" }}
-            - name: CONFIGMAP_NAME
-              value: {{ .Values.configMap.name }}
+              ## for daemonset
+            - name: CONFIGMAP_DAEMONSET_NAME
+              value: {{ .Values.configMapDaemonset.name }}
+              ## for deployment
+            - name: CONFIGMAP_DEPLOYMENT_NAME
+              value: {{ .Values.configMapDeployment.name }}
             - name: KM_CLUSTER_NAME
               value: {{ .Values.clusterName }}
             - name: KM_NAMESPACE
@@ -44,10 +46,18 @@ spec:
                   fieldPath: metadata.namespace
             - name: KM_DAEMONSET_NAME
               value: {{ .Values.daemonsetName }}
+            - name: KM_DEPLOYMENT_NAME
+              value: {{ .Values.deploymentName }}
 
           volumeMounts:
-            - name: agent-config-volume
-              mountPath: "/etc/kmagent/agent.yaml"
+              ## for daemonset 
+            - name: agent-config-volume-daemonset
+              mountPath: "/etc/kmagent/agent-daemonset.yaml"
+              readOnly: true
+              subPath: "agent.yaml"
+              ## for deployment
+            - name: agent-config-volume-deployment
+              mountPath: "/etc/kmagent/agent-deployment.yaml"
               readOnly: true
               subPath: "agent.yaml"
 
@@ -60,7 +70,11 @@ spec:
               memory: "256Mi"
 
       volumes:
-        - name: agent-config-volume
+        - name: agent-config-volume-daemonset
           configMap:
-            # Assumes the ConfigMap is also managed by this chart
-            name: {{ .Values.configMap.name }}
+            ## for daemonset
+            name: {{ .Values.configMapDaemonset.name }}
+        - name: agent-config-volume-deployment
+          configMap:
+            ## for deployment
+            name: {{ .Values.configMapDeployment.name }}

--- a/deployment/helm/km-kube-agent/templates/instrumentation-crd.yaml
+++ b/deployment/helm/km-kube-agent/templates/instrumentation-crd.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- toYaml .Values.instrumentationCrdLabels | nindent 4 }}
 spec:
   exporter:
-    endpoint: http://{{ .Values.agentServiceName }}.{{ .Release.Namespace }}.svc.cluster.local:4318
+    endpoint: http://{{ .Values.agentServiceName }}.{{ .Release.Namespace }}:4318
   
   propagators:
     - tracecontext

--- a/deployment/helm/km-kube-agent/templates/instrumentation-crd.yaml
+++ b/deployment/helm/km-kube-agent/templates/instrumentation-crd.yaml
@@ -23,12 +23,7 @@ spec:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:latest
   
   env:    
-
     # Using the Downward API to dynamically set resource attributes for the pod.
-    - name: POD_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.name
     - name: POD_UID
       valueFrom:
         fieldRef:
@@ -37,10 +32,6 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-    - name: NODE_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: spec.nodeName
     - name: SERVICE_ACCOUNT_NAME
       valueFrom:
         fieldRef:

--- a/deployment/helm/km-kube-agent/templates/instrumentation-crd.yaml
+++ b/deployment/helm/km-kube-agent/templates/instrumentation-crd.yaml
@@ -6,37 +6,43 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   exporter:
-    endpoint: http://{{ .Values.agentServiceName }}.{{ .Release.Namespace }}.svc.cluster.local:4317
+    endpoint: http://{{ .Values.agentServiceName }}.{{ .Release.Namespace }}.svc.cluster.local:4318
   
   propagators:
     - tracecontext
     - baggage
     - b3
+    
   sampler:
     type: parentbased_traceidratio
-    argument: "0.25"
+    argument: "1"
 
   nodejs:
-    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.62.0 # Recommended: Use a specific, stable tag
+    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:latest
+  python:
+    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:latest
   
-  # python:
-  #   env:
-  #     # Required if endpoint is set to 4317.
-  #     # Python autoinstrumentation uses http/proto by default
-  #     # so data must be sent to 4318 instead of 4317.
-  #     - name: OTEL_EXPORTER_OTLP_ENDPOINT
-  #       value: http://otel-collector:4318
-  # dotnet:
-  #   env:
-  #     # Required if endpoint is set to 4317.
-  #     # Dotnet autoinstrumentation uses http/proto by default
-  #     # See https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/888e2cd216c77d12e56b54ee91dafbc4e7452a52/docs/config.md#otlp
-  #     - name: OTEL_EXPORTER_OTLP_ENDPOINT
-  #       value: http://otel-collector:4318
-  # go:
-  #   env:
-  #     # Required if endpoint is set to 4317.
-  #     # Go autoinstrumentation uses http/proto by default
-  #     # so data must be sent to 4318 instead of 4317.
-  #     - name: OTEL_EXPORTER_OTLP_ENDPOINT
-  #       value: http://otel-collector:4318
+  env:    
+
+    # Using the Downward API to dynamically set resource attributes for the pod.
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_UID
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.uid
+    - name: NAMESPACE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: SERVICE_ACCOUNT_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.serviceAccountName
+          

--- a/deployment/helm/km-kube-agent/templates/instrumentation-crd.yaml
+++ b/deployment/helm/km-kube-agent/templates/instrumentation-crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:
-  name: {{ .Values.InstrumentationCrd.name }}
+  name: {{ .Values.instrumentationCrdName }}
   labels:
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- toYaml .Values.instrumentationCrdLabels | nindent 4 }}
 spec:
   exporter:
     endpoint: http://{{ .Values.agentServiceName }}.{{ .Release.Namespace }}.svc.cluster.local:4318
@@ -21,6 +21,10 @@ spec:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:latest
   python:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:latest
+  dotnet:
+    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:latest
+  java:
+    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:latest
   
   env:    
     # Using the Downward API to dynamically set resource attributes for the pod.

--- a/deployment/helm/km-kube-agent/templates/polylang-daemonset.yaml
+++ b/deployment/helm/km-kube-agent/templates/polylang-daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.features.apm -}}
+{{- if .Values.featuresEnabled.apm -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/deployment/helm/km-kube-agent/templates/polylang-daemonset.yaml
+++ b/deployment/helm/km-kube-agent/templates/polylang-daemonset.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         {{- toYaml .Values.daemonsetLabels | nindent 8 }}
     spec:
-      serviceAccountName: {{ .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
       containers:
       - name: polylang-detector
         image: "{{ .Values.polylangDetector.image.repository }}:{{ .Values.polylangDetector.image.tag | default .Chart.AppVersion }}"

--- a/deployment/helm/km-kube-agent/templates/polylang-daemonset.yaml
+++ b/deployment/helm/km-kube-agent/templates/polylang-daemonset.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.features.apm -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Values.polylangDetectorDaemonsetName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- toYaml .Values.daemonsetLabels | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- toYaml .Values.daemonsetLabels | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- toYaml .Values.daemonsetLabels | nindent 8 }}
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      containers:
+      - name: polylang-detector
+        image: "{{ .Values.polylangDetector.image.repository }}:{{ .Values.polylangDetector.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.polylangDetector.image.pullPolicy }}
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "250m"
+            memory: "256Mi"
+{{- end }}

--- a/deployment/helm/km-kube-agent/templates/serviceaccount.yaml
+++ b/deployment/helm/km-kube-agent/templates/serviceaccount.yaml
@@ -1,14 +1,10 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.autoCreateServiceAccount -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "km-kube-agent.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+    {{- toYaml .Values.serviceLabels | nindent 4 }}
+automountServiceAccountToken: {{ .Values.autoMountServiceAccount }}
 {{- end }}

--- a/deployment/helm/km-kube-agent/values.yaml
+++ b/deployment/helm/km-kube-agent/values.yaml
@@ -1,21 +1,50 @@
 replicaCount: 1
 
+# kloudmate platform specific arguments
 API_KEY:
 COLLECTOR_ENDPOINT: https://otel.kloudmate.com:4318
 KM_UPDATE_ENDPOINT: https://api.kloudmate.com/agents/config-check
 KM_CONFIG_CHECK_INTERVAL: 30s
 
-daemonsetName: kloudmate-agent
-agentServiceName: kloudmate-agent-service
+# names of components to be installed.
+daemonsetName: km-agent-daemonset
+deploymentName: km-agent-deployment
+clusterRoleName: km-agent-cluster-role
+agentServiceName: km-agent-svc
+configUpdaterName: km-agent-config-updater
+serviceAccountName: km-agent-sa
+clusterRoleBindingName: km-agent-cluster-role-binding 
+instrumentationCrdName: km-agent-instrumentation-crd
+configMapDaemonsetName: km-agent-configmap-daemonset
+configMapDeploymentName: km-agent-configmap-deployment 
+polylangDetectorDaemonsetName: km-agent-polylang-detector-daemonset 
 
+autoMountServiceAccount: true
+autoCreateServiceAccount: true
+
+featuresEnabled:
+  apm: true
+  logs: true
+  metrics: true
+  traces: true
+
+# image settings for kube agent
 image:
   repository: ghcr.io/kloudmate/km-kube-agent
   pullPolicy: Always
   tag: "latest"
 
+# image settings for config updater
 configUpdater:
   image:
     repository: ghcr.io/kloudmate/km-kube-updater
+    pullPolicy: Always
+    tag: "latest"
+
+# image settings for polylang-detector
+polylangDetector:
+  image:
+    repository: ghcr.io/kloudmate/polylang-detector
     pullPolicy: Always
     tag: "latest"
 
@@ -23,56 +52,38 @@ configUpdater:
 nameOverride: ""
 fullnameOverride: ""
 
-# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
-serviceAccount:
-  # Specifies whether a service account should be created
-  create: true
-  # Automatically mount a ServiceAccount's API credentials?
-  automount: true
-  # Annotations to add to the service account
-  annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name: "km-svc-account"
-
-rbac:
-  # -- The ClusterRole name
-  clusterRoleName: km-cluster-role
-  clusterRoleNamespace: default
-
-  ClusterRoleBindingName: km-agent-cluster-binding
-  ClusterRoleBindingNamespace: default
-
-configMap:
-  name: "km-agent-configmap"
-
-InstrumentationCrd:
-  name: instrumentation-crd
-
-# This is for setting Kubernetes Annotations to a Pod.
-# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-podAnnotations: {}
-# This is for setting Kubernetes Labels to a Pod.
-# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
-
-securityContext: {}
-
-
-selectorLabels:
-  app.kubernetes.io/component: km-km-kube-agent
-
-extraLabels:
-  app.kubernetes.io/name: km-k8sdaemonset
-  app.kubernetes.io/instance: kloudmate-prod-release # Or "{{ .Release.Name }}" in Helm
-  app.kubernetes.io/component: km-km-kube-agent-deployment
-  app.kubernetes.io/part-of: observability-apm
-
-
 # ----------- Labels ------------
+
+# Labels for the DaemonSet, which acts as a node-level agent.
+daemonsetLabels:
+  app.kubernetes.io/name: "km-kube-agent"
+  app.kubernetes.io/instance: "km-kube-agent-daemonset"
+  app.kubernetes.io/component: "node-agent"
+  app.kubernetes.io/part-of: "kloudmate-platform"
+  app.kubernetes.io/managed-by: "Helm"
+  environment: "production"
+  product: "kloudmate"
+
+# Labels for the Deployment, which acts as a cluster-level agent.
+deploymentLabels:
+  app.kubernetes.io/name: "km-kube-agent"
+  app.kubernetes.io/instance: "km-kube-agent-deployment"
+  app.kubernetes.io/component: "cluster-agent"
+  app.kubernetes.io/part-of: "kloudmate-platform"
+  app.kubernetes.io/managed-by: "Helm"
+  environment: "production"
+  product: "kloudmate"
+
+# Labels for the Config Updater.
+configUpdaterLabels:
+  app.kubernetes.io/name: "km-kube-agent"
+  app.kubernetes.io/instance: "km-kube-agent-config-updater"
+  app.kubernetes.io/part-of: "kloudmate-platform"
+  app.kubernetes.io/managed-by: "Helm"
+  product: "kloudmate"
+
 
 # Labels for the Service Account.
 serviceAccountLabels:
@@ -114,7 +125,7 @@ serviceLabels:
   app.kubernetes.io/managed-by: "Helm"
   product: "kloudmate"
 
-# Labels for the ConfigMap.
+# Labels for the Deployment ConfigMap.
 configMapDeploymentLabels:
   app.kubernetes.io/name: "km-kube-agent"
   app.kubernetes.io/instance: "km-kube-agent-config-deployment"
@@ -122,7 +133,7 @@ configMapDeploymentLabels:
   app.kubernetes.io/managed-by: "Helm"
   product: "kloudmate"
 
-# Labels for the ConfigMap.
+# Labels for the Daemonset ConfigMap.
 configMapDaemonsetLabels:
   app.kubernetes.io/name: "km-kube-agent"
   app.kubernetes.io/instance: "km-kube-agent-config-daemonset"
@@ -137,39 +148,25 @@ opentelemetry-operator:
     # Set to 'false' if you are managing CRDs externally, or 'true' to let the operator manage them.
     # The current setting 'true' is fine, but double-check your installation strategy.
     create: true
-  enabled: true # install the operator as part of this chart
+  enabled: true
   admissionWebhooks:
     create: true
     servicePort: 443
-    # Change the failure policy for pods from 'Ignore' to 'Fail' if you want pods
-    # to fail creation if the webhook is not available.
     pods:
       failurePolicy: Fail
-
-    ## Adds a prefix to the mutating webhook name.
-    ## This can be used to order this mutating webhook with all cluster's mutating webhooks.
     namePrefix: ""
-
-    ## Customize webhook timeout duration
     timeoutSeconds: 10
-
-    ## Provide selectors for objects
     namespaceSelector: {}
     objectSelector: {}
     certManager:
       enabled: false
 
-    ## Use Helm to automatically generate self-signed certificate.
     ## certManager must be disabled and autoGenerateCert must be enabled.
     ## If true and certManager.enabled is false, Helm will automatically create a self-signed cert and secret.
     autoGenerateCert:
       enabled: true
-      # If set to true, new webhook key/certificate is generated on helm upgrade.
       recreate: true
-      # Cert period time in days. The default is 365 days.
-      certPeriodDays: 365
-  
-
+      certPeriodDays: 365  
   manager:
     resources: {}
     autoInstrumentationImage:
@@ -189,8 +186,6 @@ opentelemetry-operator:
 # ----------- cert-manager ------------
 cert-manager:
   enabled: false
-  # Set crds.enabled to 'true' to have cert-manager install and manage its own CRDs.
-  # It's a common source of bugs for cert-manager to have its CRDs managed externally.
   crds:
     enabled: false
     keep: true

--- a/deployment/helm/km-kube-agent/values.yaml
+++ b/deployment/helm/km-kube-agent/values.yaml
@@ -7,6 +7,7 @@ KM_UPDATE_ENDPOINT: https://api.kloudmate.com/agents/config-check
 KM_CONFIG_CHECK_INTERVAL: 30s
 
 # names of components to be installed.
+clusterName: 
 daemonsetName: km-agent-daemonset
 deploymentName: km-agent-deployment
 clusterRoleName: km-agent-cluster-role

--- a/deployment/helm/km-kube-agent/values.yaml
+++ b/deployment/helm/km-kube-agent/values.yaml
@@ -1,7 +1,5 @@
-# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
 replicaCount: 1
 
-# The api key is a must to be passed and it will be injected in the configmap
 API_KEY:
 COLLECTOR_ENDPOINT: https://otel.kloudmate.com:4318
 KM_UPDATE_ENDPOINT: https://api.kloudmate.com/agents/config-check
@@ -9,21 +7,16 @@ KM_CONFIG_CHECK_INTERVAL: 30s
 
 daemonsetName: kloudmate-agent
 agentServiceName: kloudmate-agent-service
-# Kubernetes agent image configuration
+
 image:
   repository: ghcr.io/kloudmate/km-kube-agent
-  # This sets the pull policy for images.
   pullPolicy: Always
-  # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
 
-# Kubernetes agent config updater image configuration
 configUpdater:
   image:
     repository: ghcr.io/kloudmate/km-kube-updater
-    # This sets the pull policy for images.
     pullPolicy: Always
-    # Overrides the image tag whose default is the chart appVersion.
     tag: "latest"
 
 # This is to override the chart name.
@@ -68,18 +61,6 @@ podSecurityContext: {}
 
 securityContext: {}
 
-# Additional volumes on the output Deployment definition.
-volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
-
-# Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
 
 selectorLabels:
   app.kubernetes.io/component: km-km-kube-agent
@@ -89,6 +70,65 @@ extraLabels:
   app.kubernetes.io/instance: kloudmate-prod-release # Or "{{ .Release.Name }}" in Helm
   app.kubernetes.io/component: km-km-kube-agent-deployment
   app.kubernetes.io/part-of: observability-apm
+
+
+# ----------- Labels ------------
+
+# Labels for the Service Account.
+serviceAccountLabels:
+  app.kubernetes.io/name: "km-kube-agent"
+  app.kubernetes.io/instance: "km-kube-agent-sa"
+  app.kubernetes.io/part-of: "kloudmate-platform"
+  app.kubernetes.io/managed-by: "Helm"
+  product: "kloudmate"
+
+# Labels for the Cluster Role.
+clusterRoleLabels:
+  app.kubernetes.io/name: "km-kube-agent"
+  app.kubernetes.io/instance: "km-kube-agent-clusterrole"
+  app.kubernetes.io/part-of: "kloudmate-platform"
+  app.kubernetes.io/managed-by: "Helm"
+  product: "kloudmate"
+
+# Labels for the Cluster Role Binding.
+clusterRoleBindingLabels:
+  app.kubernetes.io/name: "km-kube-agent"
+  app.kubernetes.io/instance: "km-kube-agent-clusterrolebinding"
+  app.kubernetes.io/part-of: "kloudmate-platform"
+  app.kubernetes.io/managed-by: "Helm"
+  product: "kloudmate"
+
+# Labels for the Instrumentation CRD.
+instrumentationCrdLabels:
+  app.kubernetes.io/name: "km-kube-instrumentation"
+  app.kubernetes.io/instance: "km-kube-instrumentation-crd"
+  app.kubernetes.io/part-of: "kloudmate-platform"
+  app.kubernetes.io/managed-by: "Helm"
+  product: "kloudmate"
+
+# Labels for the Service.
+serviceLabels:
+  app.kubernetes.io/name: "km-kube-agent"
+  app.kubernetes.io/instance: "km-kube-agent-service"
+  app.kubernetes.io/part-of: "kloudmate-platform"
+  app.kubernetes.io/managed-by: "Helm"
+  product: "kloudmate"
+
+# Labels for the ConfigMap.
+configMapDeploymentLabels:
+  app.kubernetes.io/name: "km-kube-agent"
+  app.kubernetes.io/instance: "km-kube-agent-config-deployment"
+  app.kubernetes.io/part-of: "kloudmate-platform"
+  app.kubernetes.io/managed-by: "Helm"
+  product: "kloudmate"
+
+# Labels for the ConfigMap.
+configMapDaemonsetLabels:
+  app.kubernetes.io/name: "km-kube-agent"
+  app.kubernetes.io/instance: "km-kube-agent-config-daemonset"
+  app.kubernetes.io/part-of: "kloudmate-platform"
+  app.kubernetes.io/managed-by: "Helm"
+  product: "kloudmate"
 
 
 # ----------- Operator ------------

--- a/deployment/helm/km-kube-agent/values.yaml
+++ b/deployment/helm/km-kube-agent/values.yaml
@@ -15,7 +15,7 @@ image:
   # This sets the pull policy for images.
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v2"
+  tag: "latest"
 
 # Kubernetes agent config updater image configuration
 configUpdater:
@@ -94,19 +94,17 @@ extraLabels:
 # ----------- Operator ------------
 opentelemetry-operator:
   crds:
+    # Set to 'false' if you are managing CRDs externally, or 'true' to let the operator manage them.
+    # The current setting 'true' is fine, but double-check your installation strategy.
     create: true
   enabled: true # install the operator as part of this chart
   admissionWebhooks:
-    certManager:
-      enabled: true
     create: true
     servicePort: 443
-    failurePolicy: Fail
-    secretName: ""
-
-    ## Defines the sidecar injection logic in Pods.
+    # Change the failure policy for pods from 'Ignore' to 'Fail' if you want pods
+    # to fail creation if the webhook is not available.
     pods:
-      failurePolicy: Ignore
+      failurePolicy: Fail
 
     ## Adds a prefix to the mutating webhook name.
     ## This can be used to order this mutating webhook with all cluster's mutating webhooks.
@@ -119,16 +117,7 @@ opentelemetry-operator:
     namespaceSelector: {}
     objectSelector: {}
     certManager:
-      enabled: true
-      ## Provide the issuer kind and name to do the cert auth job.
-      ## By default, OpenTelemetry Operator will use self-signer issuer.
-      issuerRef: {}
-      ## Annotations for the cert and issuer if cert-manager is enabled.
-      certificateAnnotations: {}
-      issuerAnnotations: {}
-      # duration must be specified by a Go time.Duration (ending in s, m or h)
-      duration: ""
-      renewBefore: ""
+      enabled: false
 
     ## Use Helm to automatically generate self-signed certificate.
     ## certManager must be disabled and autoGenerateCert must be enabled.
@@ -143,10 +132,7 @@ opentelemetry-operator:
 
   manager:
     resources: {}
-    # createCollector: false
     autoInstrumentationImage:
-      # This section defines the auto-instrumentation images for different languages.
-      # The operator will use these images for the initContainer when injecting.
       nodejs:
         repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs
         tag: latest
@@ -160,8 +146,11 @@ opentelemetry-operator:
         repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet
         tag: latest
 
+# ----------- cert-manager ------------
 cert-manager:
-  enabled: true
+  enabled: false
+  # Set crds.enabled to 'true' to have cert-manager install and manage its own CRDs.
+  # It's a common source of bugs for cert-manager to have its CRDs managed externally.
   crds:
     enabled: false
     keep: true

--- a/internal/config/config_k8s.go
+++ b/internal/config/config_k8s.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	DefaultConfigmapMountPath = "/etc/kmagent/agent.yaml"
+	// DefaultConfigmapMountPath = "/etc/kmagent/agent.yaml"
 
 	EnvAPIKey              = "KM_API_KEY"
 	EnvAgentConfig         = "KM_AGENT_CONFIG"
@@ -30,25 +30,29 @@ type K8sAgentConfig struct {
 	APIKey              string
 	ConfigCheckInterval string
 	// Kubernetes specific
-	KubeNamespace string
-	ClusterName   string
-	ConfigmapName string
-	DaemonSetName string
+	KubeNamespace           string
+	ClusterName             string
+	DeploymentMode          string
+	ConfigmapDaemonsetName  string
+	ConfigmapDeploymentName string
+	DaemonSetName           string
+	DeploymentName          string
 }
 
 func NewKubeConfig(cfg K8sAgentConfig, clientset *kubernetes.Clientset, logger *zap.Logger) (*K8sAgentConfig, error) {
 
 	agent := &K8sAgentConfig{
-		Logger:              logger.Sugar(),
-		K8sClient:           clientset,
-		ExporterEndpoint:    cfg.ExporterEndpoint,
-		ConfigUpdateURL:     cfg.ConfigUpdateURL,
-		APIKey:              cfg.APIKey,
-		ConfigCheckInterval: cfg.ConfigCheckInterval,
-		KubeNamespace:       cfg.KubeNamespace,
-		ClusterName:         cfg.ClusterName,
-		DaemonSetName:       cfg.DaemonSetName,
-		ConfigmapName:       cfg.ConfigmapName,
+		Logger:                  logger.Sugar(),
+		K8sClient:               clientset,
+		ExporterEndpoint:        cfg.ExporterEndpoint,
+		ConfigUpdateURL:         cfg.ConfigUpdateURL,
+		APIKey:                  cfg.APIKey,
+		ConfigCheckInterval:     cfg.ConfigCheckInterval,
+		KubeNamespace:           cfg.KubeNamespace,
+		ClusterName:             cfg.ClusterName,
+		DaemonSetName:           cfg.DaemonSetName,
+		ConfigmapDaemonsetName:  cfg.ConfigmapDaemonsetName,
+		ConfigmapDeploymentName: cfg.ConfigmapDeploymentName,
 	}
 
 	agent.Logger.Infoln("kube updater initialized successfully")

--- a/internal/k8sagent/agent.go
+++ b/internal/k8sagent/agent.go
@@ -5,6 +5,8 @@ package k8sagent
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"sync"
 
 	"context"
@@ -15,8 +17,18 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+// K8sConfig holds all configuration values from environment variables
+type K8sConfig struct {
+	APIKey              string `env:"KM_API_KEY"`
+	CollectorEndpoint   string `env:"KM_COLLECTOR_ENDPOINT"`
+	ConfigCheckInterval string `env:"KM_CONFIG_CHECK_INTERVAL"`
+	DeploymentMode      string `env:"DEPLOYMENT_MODE"`
+	ConfigMapName       string `env:"CONFIGMAP_NAME"`
+	PodNamespace        string `env:"POD_NAMESPACE"`
+}
+
 type K8sAgent struct {
-	// Cfg       *config.K8sAgentConfig
+	Cfg       *K8sConfig
 	Logger    *zap.SugaredLogger
 	Collector *otelcol.Collector
 	K8sClient *kubernetes.Clientset
@@ -43,6 +55,8 @@ func NewK8sAgent(info *AgentInfo) (*K8sAgent, error) {
 	logger := zapLogger.Sugar()
 	logger.Infow("bootstrapping kube agent")
 
+	cfg := NewK8sConfig()
+
 	// ---------- Initialize Kubernetes client ----------
 
 	kubecfg, err := rest.InClusterConfig()
@@ -54,6 +68,7 @@ func NewK8sAgent(info *AgentInfo) (*K8sAgent, error) {
 
 	// ---------- Create Kube agent ----------
 	agent := &K8sAgent{
+		Cfg:       cfg,
 		Logger:    logger,
 		K8sClient: k8sClient,
 		agentInfo: *info,
@@ -105,4 +120,48 @@ func (a *K8sAgent) Stopch() {
 
 func (a *K8sAgent) AwaitShutdown() {
 	a.wg.Wait()
+}
+
+func NewK8sConfig() *K8sConfig {
+	config := &K8sConfig{
+		APIKey:            os.Getenv("KM_API_KEY"),
+		CollectorEndpoint: os.Getenv("KM_COLLECTOR_ENDPOINT"),
+		ConfigMapName:     os.Getenv("CONFIGMAP_NAME"),
+		DeploymentMode:    os.Getenv("DEPLOYMENT_MODE"),
+		PodNamespace:      os.Getenv("POD_NAMESPACE"),
+	}
+
+	if strings.ToUpper(config.DeploymentMode) == "DAEMONSET" {
+		config.DeploymentMode = "DAEMONSET"
+	} else {
+		config.DeploymentMode = "DEPLOYMENT"
+
+	}
+	return config
+}
+
+func (c *K8sConfig) Validate() error {
+	if c.APIKey == "" {
+		return fmt.Errorf("KM_API_KEY is required")
+	}
+	if c.APIKey == "" {
+		return fmt.Errorf("KM_COLLECTOR_ENDPOINT is required")
+	}
+	if c.ConfigMapName == "" {
+		return fmt.Errorf("CONFIGMAP_NAME is required")
+	}
+	if c.PodNamespace == "" {
+		return fmt.Errorf("POD_NAMESPACE is required")
+	}
+	return nil
+}
+
+func (c *K8sAgent) otelConfigPath() string {
+	daemonsetURI := "/etc/kmagent/agent-daemonset.yaml"
+	deploymentURI := "/etc/kmagent/agent-deployment.yaml"
+	if c.Cfg.DeploymentMode == "DAEMONSET" {
+		return daemonsetURI
+	} else {
+		return deploymentURI
+	}
 }

--- a/internal/k8sagent/collector.go
+++ b/internal/k8sagent/collector.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kloudmate/km-agent/internal/config"
 	"github.com/kloudmate/km-agent/internal/shared"
 	"go.opentelemetry.io/collector/otelcol"
 )
@@ -25,7 +24,7 @@ func (a *K8sAgent) startInternalCollector() error {
 
 	a.Logger.Infoln("Starting actual collector instance with new configuration...")
 
-	collectorSettings := shared.CollectorInfoFactory(config.DefaultConfigmapMountPath)
+	collectorSettings := shared.CollectorInfoFactory(a.otelConfigPath())
 
 	// Create a context for this collector instance
 	a.collectorCtx, a.collectorCancel = context.WithCancel(context.Background())
@@ -49,7 +48,7 @@ func (a *K8sAgent) startInternalCollector() error {
 			}
 		}()
 
-		a.Logger.Infof("Collector: Starting with config from %s in background goroutine... \n", config.DefaultConfigmapMountPath)
+		a.Logger.Infof("Collector: Starting with config from %s in background goroutine... \n", a.otelConfigPath())
 		err = col.Run(ctx)
 		if err != nil {
 			a.Logger.Infoln("Collector exited with error: %v", err)


### PR DESCRIPTION
- added manifest for agent deployment. (this will collect collector level metrics)
- added proper labels to all resources
- added `polylang-detector` manifest
- updated service type to local cluster - this ensures that application send metrics data to the agent installed on the same node only.
- added dotnet and java auto-instrumentation images.