### PR TITLE
Added dynamic Otel configuration update for DaemonSet and Deployment agents

### DIFF
--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -28,6 +28,21 @@ jobs:
           wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -O /usr/local/bin/yq
           chmod +x /usr/local/bin/yq
 
+      - name: Update Chart Version
+        run: |
+          NEW_VERSION=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
+          
+          yq e '.version = "'"$NEW_VERSION"'"' -i deployment/helm/km-kube-agent/Chart.yaml
+          yq e '.appVersion = "'"$NEW_VERSION"'"' -i deployment/helm/km-kube-agent/Chart.yaml
+
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add deployment/helm/km-kube-agent/Chart.yaml
+          git commit -m "chore(release): update chart version to $NEW_VERSION"
+          git push origin HEAD:${{ github.event.release.target_commitish }}
+
+
+
       - name: Add external Helm repositories
         run: |
           helm repo add jetstack https://charts.jetstack.io
@@ -79,12 +94,11 @@ jobs:
           cd gh-pages-repo
           cp ../${{ steps.package.outputs.PACKAGE_NAME }} .
 
-          sed -i "s/{{ APP_VERSION }}/${{ steps.vars.outputs.APP_VERSION }}/g" index.html
-          sed -i "s/{{ CHART_VERSION }}/${{ steps.vars.outputs.CHART_VERSION }}/g" index.html
+          sed -i "s|<span id=\"app-version\".*</span>|<span id=\"app-version\" class=\"mt-1 text-lg font-bold text-[#58a6ff]\">${{ steps.vars.outputs.APP_VERSION }}</span>|g" index.html
+          sed -i "s|<span id=\"chart-version\".*</span>|<span id=\"chart-version\" class=\"mt-1 text-lg font-bold text-[#58a6ff]\">${{ steps.vars.outputs.CHART_VERSION }}</span>|g" index.html
 
           helm repo index . --url https://${{ github.repository_owner }}.github.io/${{ github.repository }}/
 
           git add .
           git commit -m "🚀 chore(release): update index and landing page for km-kube-agent ${{ steps.vars.outputs.CHART_VERSION }}" || echo "No changes to commit"
           git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} gh-pages
-

--- a/deployment/helm/km-kube-agent/templates/agent-configmap-daemonset.yaml
+++ b/deployment/helm/km-kube-agent/templates/agent-configmap-daemonset.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   # The key here will become the filename inside the mountPath.
   # We name it exactly "agent.config.yaml" so it appears as such.
-  agent.yaml: |
+  agent-daemonset.yaml: |
 
     receivers:
       otlp:

--- a/deployment/helm/km-kube-agent/templates/agent-configmap-deployment.yaml
+++ b/deployment/helm/km-kube-agent/templates/agent-configmap-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   # The key here will become the filename inside the mountPath.
   # We name it exactly "agent.config.yaml" so it appears as such.
-  agent.yaml: |
+  agent-deployment.yaml: |
 
     receivers:
       otlp:

--- a/deployment/helm/km-kube-agent/templates/config-updater-deployment.yaml
+++ b/deployment/helm/km-kube-agent/templates/config-updater-deployment.yaml
@@ -46,17 +46,6 @@ spec:
               value: {{ .Values.daemonsetName }}
             - name: KM_DEPLOYMENT_NAME
               value: {{ .Values.deploymentName }}
-          volumeMounts:
-              ## for daemonset 
-            - name: agent-config-volume-daemonset
-              mountPath: "/etc/kmagent/agent-daemonset.yaml"
-              readOnly: true
-              subPath: "agent.yaml"
-              ## for deployment
-            - name: agent-config-volume-deployment
-              mountPath: "/etc/kmagent/agent-deployment.yaml"
-              readOnly: true
-              subPath: "agent.yaml"
           resources:
             requests:
               cpu: "100m"
@@ -64,13 +53,3 @@ spec:
             limits:
               cpu: "500m"
               memory: "256Mi"
-
-      volumes:
-        - name: agent-config-volume-daemonset
-          configMap:
-            ## for daemonset
-            name: {{ .Values.configMapDaemonsetName }}
-        - name: agent-config-volume-deployment
-          configMap:
-            ## for deployment
-            name: {{ .Values.configMapDeploymentName }}


### PR DESCRIPTION
- Adds functionality in config updater to dynamically modify the OpenTelemetry configuration for agents.
- It enables updates for agents deployed as both DaemonSets and Deployments, ensuring a unified configuration management approach across the cluster by performing intervals based polling to kloudmate APIs.