### PR TITLE
Making agent Leaner and meaner

### DIFF
--- a/cmd/configupdater/main.go
+++ b/cmd/configupdater/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/kloudmate/km-agent/internal/config"
+	kmlogger "github.com/kloudmate/km-agent/internal/logger"
 	"github.com/kloudmate/km-agent/internal/updater"
 	"github.com/kloudmate/km-agent/rpc"
 	cli "github.com/urfave/cli/v2"
@@ -88,6 +89,7 @@ func main() {
 	var agentCfg config.K8sAgentConfig
 	updaterflags := updaterFlags(&agentCfg)
 	loggerConfig := zap.NewProductionConfig()
+	loggerConfig.Level = zap.NewAtomicLevelAt(kmlogger.ParseLogLevel())
 	logger, _ := loggerConfig.Build()
 
 	app := &cli.App{

--- a/cmd/configupdater/main.go
+++ b/cmd/configupdater/main.go
@@ -3,9 +3,7 @@ package main
 import (
 	"context"
 	"os"
-	"sync"
 
-	// configupdater "github.com/kloudmate/km-agent/configupdater"
 	"github.com/kloudmate/km-agent/internal/config"
 	"github.com/kloudmate/km-agent/internal/updater"
 	"github.com/kloudmate/km-agent/rpc"
@@ -47,8 +45,9 @@ func updaterFlags(cfg *config.K8sAgentConfig) []cli.Flag {
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:        "update-endpoint",
-			Usage:       "API key for authentication",
+			Usage:       "Agent config update endpoint",
 			EnvVars:     []string{"KM_UPDATE_ENDPOINT"},
+			Value:       "https://api.kloudmate.com/agents/config-check",
 			Destination: &cfg.ConfigUpdateURL,
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
@@ -103,12 +102,12 @@ func main() {
 					ctx, cancel := context.WithCancel(c.Context)
 					defer cancel()
 
-					logger.Sugar().Infow("kloudmate config updater info",
+					logger.Sugar().Infow("starting config updater",
 						"version", version,
 						"commitSHA", commit,
 					)
 					go rpc.StartRpcServer()
-					logger.Info("loading InClusterConfig via service account.", zap.Any("config", agentCfg))
+					logger.Info("loading in-cluster kubernetes config")
 					kubeconfig, err := rest.InClusterConfig()
 					if err != nil {
 						return err
@@ -127,27 +126,17 @@ func main() {
 					kubeUpdater := updater.NewKubeConfigUpdaterClient(kubeAgentConfig, logger.Sugar())
 					kubeUpdater.SetConfigPath()
 
-					var wg sync.WaitGroup
-					errCh := make(chan error)
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
-						kubeUpdater.StartConfigUpdateChecker(ctx)
-					}()
+					logger.Info("starting config update checker")
+					kubeUpdater.StartConfigUpdateChecker(ctx)
 
-					for err := range errCh {
-						if err != nil {
-							logger.Info("error while fetching config changes", zap.Error(err))
-						}
-					}
 					close(kubeAgentConfig.StopCh)
-					wg.Wait()
+					logger.Info("config updater stopped")
 					return nil
 				},
 			},
 		},
 	}
 	if err := app.Run(os.Args); err != nil {
-		logger.Fatal("config updater cannot failed to start : ", zap.Error(err))
+		logger.Fatal("config updater failed to start", zap.Error(err))
 	}
 }

--- a/cmd/kmagent/main.go
+++ b/cmd/kmagent/main.go
@@ -210,8 +210,9 @@ func main() {
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:        "update-endpoint",
-			Usage:       "API key for authentication",
+			Usage:       "Agent config update endpoint",
 			EnvVars:     []string{"KM_UPDATE_ENDPOINT"},
+			Value:       "https://api.kloudmate.com/agents/config-check",
 			Destination: &program.cfg.ConfigUpdateURL,
 		}),
 		altsrc.NewBoolFlag(&cli.BoolFlag{

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -80,7 +80,7 @@ func (a *Agent) StartAgent(ctx context.Context) error {
 		defer a.wg.Done()
 		a.runConfigUpdateChecker(ctx)
 	}()
-	a.logger.Info("Agent start sequence initiated.")
+	a.logger.Info("agent start sequence initiated")
 	setupComplete = true
 	return nil
 }
@@ -88,11 +88,11 @@ func (a *Agent) StartAgent(ctx context.Context) error {
 // Shutdown gracefully shuts down the agent
 func (a *Agent) Shutdown(ctx context.Context) error {
 	if !a.isRunning.CompareAndSwap(true, false) {
-		a.logger.Info("Agent shutdown called, but agent is not marked as running.")
+		a.logger.Debug("shutdown called but agent is not running")
 		return nil
 	}
 	close(a.shutdownSignal)
-	a.logger.Info("Stopping current collector instance (if any).")
+	a.logger.Info("stopping collector instance")
 	a.stopCollectorInstance()
 
 	waitCh := make(chan struct{})
@@ -103,7 +103,7 @@ func (a *Agent) Shutdown(ctx context.Context) error {
 
 	select {
 	case <-waitCh:
-		a.logger.Info("All agent goroutines completed.")
+		a.logger.Info("all agent goroutines completed")
 	case <-ctx.Done():
 		a.logger.Errorf("Agent shutdown timed out: %v", ctx.Err())
 		return ctx.Err()
@@ -114,7 +114,7 @@ func (a *Agent) Shutdown(ctx context.Context) error {
 func (a *Agent) manageCollectorLifecycle(ctx context.Context) error {
 	// Initial check to exit early and avoid unnecessary work.
 	if !a.isRunning.Load() {
-		a.logger.Info("Agent is shutting down, not starting new collector.")
+		a.logger.Info("agent shutting down, skipping collector start")
 		return nil
 	}
 
@@ -133,7 +133,7 @@ func (a *Agent) manageCollectorLifecycle(ctx context.Context) error {
 		// This prevents a race condition if another collector was started in the meantime.
 		if a.collector == collector {
 			a.collector = nil
-			a.logger.Debug("Collector instance cleared from agent.")
+			a.logger.Debug("collector instance cleared")
 		}
 	}()
 
@@ -142,20 +142,21 @@ func (a *Agent) manageCollectorLifecycle(ctx context.Context) error {
 	if !a.isRunning.Load() {
 		// The agent was shut down between the initial check and now. Abort.
 		a.collectorMu.Unlock()
-		a.logger.Info("Agent shutdown initiated, aborting collector start.")
+		a.logger.Info("agent shutdown initiated, aborting collector start")
 		return nil // Or a specific error if desired, like context.Canceled
 	}
 	a.collector = collector
 	a.collectorMu.Unlock()
 
-	a.logger.Info("Collector instance created. Starting its run loop...")
+	a.logger.Info("collector instance created, starting run loop")
 	runErr := collector.Run(ctx)
 	if runErr != nil {
 		a.collectorError = runErr.Error()
+		a.logger.Errorw("collector run loop exited with error", "error", runErr)
 	} else {
 		a.collectorError = ""
+		a.logger.Info("collector run loop exited normally")
 	}
-	a.logger.Infof("Collector run loop finished. Error: %v", runErr)
 
 	return runErr
 }
@@ -167,9 +168,9 @@ func (a *Agent) stopCollectorInstance() {
 	a.collectorMu.Unlock()
 
 	if collector != nil {
-		a.logger.Info("Initiating shutdown for active collector instance...")
+		a.logger.Info("shutting down active collector instance")
 		collector.Shutdown()
-		a.logger.Info("Collector shutdown signal sent.")
+		a.logger.Info("collector shutdown complete")
 	}
 }
 
@@ -186,21 +187,24 @@ func (a *Agent) UpdateConfig(_ context.Context, newConfig map[string]interface{}
 	if err := os.Rename(tempFile, a.cfg.OtelConfigPath); err != nil {
 		return fmt.Errorf("failed to replace config file: %w", err)
 	}
-	a.logger.Info("Successfully updated collector configuration")
+	a.logger.Infow("collector configuration updated", "configPath", a.cfg.OtelConfigPath)
 	return nil
 }
 
 // runConfigUpdateChecker run ticker for performConfigCheck
 func (a *Agent) runConfigUpdateChecker(ctx context.Context) {
 	if a.cfg.ConfigUpdateURL == "" {
-		a.logger.Info("Config update URL not configured, skipping config update checks")
+		a.logger.Debug("config update URL not configured, skipping update checks")
 		return
 	}
 	if a.cfg.ConfigCheckInterval <= 0 {
-		a.logger.Info("Config check interval not set or invalid, skipping config update checks")
+		a.logger.Debug("config check interval not set, skipping update checks")
 		return
 	}
-	a.logger.Infof("Config update URL %s started with interval %ds", a.cfg.ConfigUpdateURL, a.cfg.ConfigCheckInterval)
+	a.logger.Infow("config update checker started",
+		"updateURL", a.cfg.ConfigUpdateURL,
+		"intervalSeconds", a.cfg.ConfigCheckInterval,
+	)
 	ticker := time.NewTicker(time.Duration(a.cfg.ConfigCheckInterval) * time.Second)
 	defer ticker.Stop()
 
@@ -216,10 +220,10 @@ func (a *Agent) runConfigUpdateChecker(ctx context.Context) {
 				a.logger.Errorf("Periodic config check failed: %v", err)
 			}
 		case <-a.shutdownSignal:
-			a.logger.Info("Config update checker stopping due to shutdown.")
+			a.logger.Info("config update checker stopping")
 			return
 		case <-ctx.Done():
-			a.logger.Info("Config update checker stopping due to context cancellation.")
+			a.logger.Info("config update checker stopping")
 			return
 		}
 	}
@@ -230,7 +234,7 @@ func (a *Agent) performConfigCheck(agentCtx context.Context) error {
 	ctx, cancel := context.WithTimeout(agentCtx, 10*time.Second)
 	defer cancel()
 
-	a.logger.Info("Checking for configuration updates...")
+	a.logger.Debug("checking for configuration updates")
 
 	a.collectorMu.Lock()
 	params := updater.UpdateCheckerParams{
@@ -261,14 +265,9 @@ func (a *Agent) performConfigCheck(agentCtx context.Context) error {
 			a.collectorError = err.Error()
 			return fmt.Errorf("failed to update config file: %w", err)
 		}
-		a.logger.Info("Configuration change requires collector restart.")
+		a.logger.Info("configuration changed, restarting collector")
 		if !a.isRunning.Load() {
-			a.logger.Info("Agent is shutting down, skipping restart.")
-			return nil
-		}
-
-		if !a.isRunning.Load() {
-			a.logger.Info("Agent is shutting down, skipping restart.")
+			a.logger.Info("agent shutting down, skipping restart")
 			return nil
 		}
 
@@ -279,12 +278,12 @@ func (a *Agent) performConfigCheck(agentCtx context.Context) error {
 			if err := a.manageCollectorLifecycle(agentCtx); err != nil {
 				a.collectorError = err.Error()
 			} else {
-				a.logger.Info("Collector restarted successfully.")
+				a.logger.Info("collector restarted successfully")
 				a.collectorError = ""
 			}
 		}()
 	} else {
-		a.logger.Info("No configuration change or restart required.")
+		a.logger.Debug("no configuration change detected")
 	}
 	return nil
 }

--- a/internal/agent/collector.go
+++ b/internal/agent/collector.go
@@ -1,8 +1,6 @@
 package agent
 
 import (
-	"fmt"
-
 	"github.com/kloudmate/km-agent/internal/config"
 	"github.com/kloudmate/km-agent/internal/shared"
 	"go.opentelemetry.io/collector/otelcol"
@@ -10,7 +8,5 @@ import (
 
 func NewCollector(c *config.Config) (*otelcol.Collector, error) {
 	collectorSettings := shared.CollectorInfoFactory(c.OtelConfigPath)
-	fmt.Println("New collector created")
-
 	return otelcol.NewCollector(collectorSettings)
 }

--- a/internal/k8sagent/agent.go
+++ b/internal/k8sagent/agent.go
@@ -46,26 +46,25 @@ type AgentInfo struct {
 }
 
 func NewK8sAgent(info *AgentInfo) (*K8sAgent, error) {
-	// ---------- Logging ----------
 	zapLogger, err := zap.NewProduction()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize logger: %w", err)
 	}
 	logger := zapLogger.Sugar()
-	logger.Infow("bootstrapping kube agent")
 
 	cfg := NewK8sConfig()
-
-	// ---------- Initialize Kubernetes client ----------
 
 	kubecfg, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load in-cluster config: %w", err)
 	}
-	logger.Infof("loaded cluster info from In-Cluster service account")
-	k8sClient, err := kubernetes.NewForConfig(kubecfg)
+	logger.Info("loaded in-cluster kubernetes config")
 
-	// ---------- Create Kube agent ----------
+	k8sClient, err := kubernetes.NewForConfig(kubecfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
 	agent := &K8sAgent{
 		Cfg:       cfg,
 		Logger:    logger,
@@ -75,45 +74,41 @@ func NewK8sAgent(info *AgentInfo) (*K8sAgent, error) {
 	}
 	agent.AgentInfo.setEnvForAgentVersion()
 	agent.AgentInfo.CollectorVersion = version.GetCollectorVersion()
-	logger.Infoln("kube agent initialized successfully")
+
+	logger.Infow("kube agent initialized",
+		"version", info.Version,
+		"commit", info.CommitSHA,
+		"deploymentMode", cfg.DeploymentMode,
+	)
 	return agent, nil
 }
 
-// StartAgent first creates a otel config from agent config and then runs the agent
+// StartAgent creates an otel config from agent config and then runs the agent.
 func (km *K8sAgent) StartAgent(ctx context.Context) error {
-	km.Logger.Infow("kloudmate kubernetes agent info",
+	km.Logger.Infow("starting kubernetes agent",
 		"version", km.AgentInfo.Version,
 		"commitSHA", km.AgentInfo.CommitSHA,
-		"collector-version", km.AgentInfo.CollectorVersion,
+		"collectorVersion", km.AgentInfo.CollectorVersion,
 	)
 	return km.Start(ctx)
 }
 
-// Start runs the agent with otel config from the default path
+// Start runs the agent with otel config from the default path.
 func (a *K8sAgent) Start(ctx context.Context) error {
-	a.Logger.Infoln("Starting collector agent...")
-
-	// Start the initial collector instance
 	if err := a.startInternalCollector(); err != nil {
-		return fmt.Errorf("failed to start initial collector: %w", err)
-	} else {
-		a.Logger.Infoln("collector agent started successfully.")
+		return fmt.Errorf("failed to start collector: %w", err)
 	}
+	a.Logger.Info("collector agent started")
 	return nil
 }
 
-// Stop stops the underlying collector
+// Stop stops the underlying collector.
 func (a *K8sAgent) Stop() {
-	a.Logger.Infoln("Stopping collector agent...")
-
-	// Signal the polling goroutine to stop
+	a.Logger.Info("stopping collector agent")
 	close(a.stopCh)
 	a.wg.Wait()
-
-	// Stop the collector instance
 	a.stopInternalCollector()
-
-	a.Logger.Infoln("Collector agent stopped.")
+	a.Logger.Info("collector agent stopped")
 }
 
 func (a *K8sAgent) Stopch() {
@@ -126,7 +121,7 @@ func (a *K8sAgent) AwaitShutdown() {
 
 func NewK8sConfig() *K8sConfig {
 	config := &K8sConfig{
-		ConfigCheckInterval: os.Getenv(""),
+		ConfigCheckInterval: os.Getenv("KM_CONFIG_CHECK_INTERVAL"),
 		APIKey:              os.Getenv("KM_API_KEY"),
 		CollectorEndpoint:   os.Getenv("KM_COLLECTOR_ENDPOINT"),
 		ConfigMapName:       os.Getenv("CONFIGMAP_NAME"),
@@ -147,7 +142,7 @@ func (c *K8sConfig) Validate() error {
 	if c.APIKey == "" {
 		return fmt.Errorf("KM_API_KEY is required")
 	}
-	if c.APIKey == "" {
+	if c.CollectorEndpoint == "" {
 		return fmt.Errorf("KM_COLLECTOR_ENDPOINT is required")
 	}
 	if c.ConfigMapName == "" {

--- a/internal/k8sagent/agent.go
+++ b/internal/k8sagent/agent.go
@@ -8,6 +8,7 @@ import (
 
 	"context"
 
+	kmlogger "github.com/kloudmate/km-agent/internal/logger"
 	"github.com/kloudmate/km-agent/internal/version"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.uber.org/zap"
@@ -46,7 +47,9 @@ type AgentInfo struct {
 }
 
 func NewK8sAgent(info *AgentInfo) (*K8sAgent, error) {
-	zapLogger, err := zap.NewProduction()
+	zapCfg := zap.NewProductionConfig()
+	zapCfg.Level = zap.NewAtomicLevelAt(kmlogger.ParseLogLevel())
+	zapLogger, err := zapCfg.Build()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize logger: %w", err)
 	}

--- a/internal/k8sagent/collector.go
+++ b/internal/k8sagent/collector.go
@@ -13,7 +13,7 @@ func (a *K8sAgent) startInternalCollector() error {
 	a.collectorMu.Lock()
 	defer a.collectorMu.Unlock()
 
-	a.Logger.Infoln("Starting actual collector instance with new configuration...")
+	a.Logger.Info("starting collector instance")
 
 	collectorSettings := shared.CollectorInfoFactory(a.otelConfigPath())
 	if a.Cfg.DeploymentMode == "DEPLOYMENT" {
@@ -41,41 +41,31 @@ func (a *K8sAgent) startInternalCollector() error {
 	a.Collector = collector
 
 	// Start the collector in a separate goroutine.
-	// The collector's Start method is blocking until the collector is ready or fails.
 	a.wg.Add(1)
 	go func(col *otelcol.Collector, ctx context.Context) {
-		defer func() {
-			a.wg.Done()
-			if err != nil {
-				a.Logger.Infoln("Collector exited with error: %v", err)
+		defer a.wg.Done()
 
-			}
-		}()
+		a.Logger.Infow("collector starting",
+			"configPath", a.otelConfigPath(),
+			"deploymentMode", a.Cfg.DeploymentMode,
+		)
 
-		a.Logger.Infof("Collector: Starting with configMap mounted in path:  [%s] \n", a.otelConfigPath())
-		err = col.Run(ctx)
-		if err != nil {
-			a.Logger.Infoln("Collector exited with error: %v", err)
+		runErr := col.Run(ctx)
 
-		} else {
-			a.Logger.Infoln("Collector exited normally.")
-		}
 		a.collectorMu.Lock()
-		defer func() {
-			if err != nil {
-				a.Logger.Infoln("Collector exited with error: %v", err)
-
-			}
-			a.collectorMu.Unlock()
-		}()
-
 		if a.Collector == col {
 			a.Collector = nil
 		}
+		a.collectorMu.Unlock()
 
+		if runErr != nil {
+			a.Logger.Errorw("collector exited with error", "error", runErr)
+		} else {
+			a.Logger.Info("collector exited normally")
+		}
 	}(a.Collector, a.collectorCtx)
 
-	a.Logger.Infoln("Collector instance started.")
+	a.Logger.Info("collector instance started")
 	return nil
 }
 
@@ -84,7 +74,12 @@ func (a *K8sAgent) stopInternalCollector() {
 	a.collectorMu.Lock()
 	defer a.collectorMu.Unlock()
 
-	a.Logger.Infoln("Attempting to stop collector instance gracefully...")
+	if a.Collector == nil {
+		a.Logger.Debug("no active collector instance to stop")
+		return
+	}
+
+	a.Logger.Info("stopping collector instance")
 
 	// Signal the collector's context to cancel its operations
 	if a.collectorCancel != nil {
@@ -104,9 +99,9 @@ func (a *K8sAgent) stopInternalCollector() {
 
 	select {
 	case <-done:
-		a.Logger.Infoln("Collector instance stopped successfully.")
+		a.Logger.Info("collector instance stopped successfully")
 	case <-shutdownCtx.Done():
-		a.Logger.Infoln("Collector shutdown timed out after 10 seconds: %v", shutdownCtx.Err())
+		a.Logger.Warnw("collector shutdown timed out", "timeout", "10s", "error", shutdownCtx.Err())
 	}
 
 	a.Collector = nil

--- a/internal/logger/level.go
+++ b/internal/logger/level.go
@@ -1,0 +1,24 @@
+package logger
+
+import (
+	"os"
+	"strings"
+
+	"go.uber.org/zap/zapcore"
+)
+
+// ParseLogLevel reads the KM_LOG_LEVEL environment variable and returns the
+// corresponding zapcore.Level. Supported values: debug, info, warn, error.
+// @amitava82: here it defaults to InfoLevel if unset or unrecognized.
+func ParseLogLevel() zapcore.Level {
+	switch strings.ToLower(os.Getenv("KM_LOG_LEVEL")) {
+	case "debug":
+		return zapcore.DebugLevel
+	case "warn", "warning":
+		return zapcore.WarnLevel
+	case "error":
+		return zapcore.ErrorLevel
+	default:
+		return zapcore.InfoLevel
+	}
+}

--- a/internal/logger/unix_log.go
+++ b/internal/logger/unix_log.go
@@ -16,7 +16,9 @@ type KmLogger struct {
 
 // SetupLogger returns simple logger for unix systems
 func SetupLogger() *KmLogger {
-	logger, err := zap.NewProduction()
+	cfg := zap.NewProductionConfig()
+	cfg.Level = zap.NewAtomicLevelAt(ParseLogLevel())
+	logger, err := cfg.Build()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create logger: %v\n", err)
 		os.Exit(1)

--- a/internal/logger/win_log.go
+++ b/internal/logger/win_log.go
@@ -76,7 +76,7 @@ func SetupLogger() *KmLogger {
 	loggerCore := zapcore.NewCore(
 		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
 		winlogSyncer,
-		zapcore.InfoLevel,
+		ParseLogLevel(),
 	)
 
 	logger := zap.New(loggerCore)

--- a/internal/shared/collector_info.go
+++ b/internal/shared/collector_info.go
@@ -1,8 +1,6 @@
 package shared
 
 import (
-	"fmt"
-
 	"github.com/kloudmate/km-agent/internal/version"
 
 	"go.opentelemetry.io/collector/component"
@@ -14,15 +12,11 @@ import (
 )
 
 func CollectorInfoFactory(cfgPath string) otelcol.CollectorSettings {
-
 	info := component.BuildInfo{
 		Command:     "kmagent",
 		Description: "KloudMate Agent for OpenTelemetry",
-		// Collector version
-		Version: version.GetCollectorVersion(),
+		Version:     version.GetCollectorVersion(),
 	}
-
-	fmt.Println("config file ", cfgPath)
 
 	return otelcol.CollectorSettings{
 		BuildInfo:               info,
@@ -39,6 +33,6 @@ func CollectorInfoFactory(cfgPath string) otelcol.CollectorSettings {
 				},
 			},
 		},
-		SkipSettingGRPCLogger: true, // Prevents gRPC from setting its own logger, uses zap instead
+		SkipSettingGRPCLogger: true,
 	}
 }

--- a/internal/shared/components_kubernetes.go
+++ b/internal/shared/components_kubernetes.go
@@ -25,7 +25,8 @@ func Components() (otelcol.Factories, error) {
 	processors := BaseProcessorFactories()
 	connectors := BaseConnectorFactories()
 
-	receivers := kubernetesReceivers()
+	receivers := BaseReceiverFactories()
+	receivers = append(receivers, kubernetesReceivers()...)
 
 	extensions = append(extensions, kubernetesExtensions()...)
 


### PR DESCRIPTION
#### **Work In Progress**
- In config updater: errCh code (channel was never written to, for range `errCh` blocked forever) causing deadlock.
- fixed logging formatting.
- Introduced `KM_LOG_LEVEL` variable
- switched unnecessary logs from info level logs to warn, debug logs to clean the the unnecessary bombarding of unwanted jargon messages on `stdout`.
- removed boilerplate code that we added initially.
